### PR TITLE
Add customizable ignored patterns (ex. spaces-only selection)

### DIFF
--- a/selection-highlight-mode.el
+++ b/selection-highlight-mode.el
@@ -28,6 +28,8 @@
 
 ;;; Code:
 
+(autoload 'cl-some "cl-extra")
+
 ;;; Settings
 
 (defgroup selection-highlight nil
@@ -38,6 +40,11 @@
   "The minimum length of selection before highlighting matches."
   :group 'selection-highlight
   :type 'natnum)
+
+(defcustom selection-highlight-ignored-matches '("^[[:space:]]*$")
+  "Ignore the selection text if it matches one of these regexps."
+  :group 'selection-highlight
+  :type '(repeat regexp))
 
 ;;; State
 
@@ -174,7 +181,9 @@ Keys off WINDOW."
            (block-cursor? (and (fboundp 'evil-visual-state-p)
                                (evil-visual-state-p)))
            (end (+ (region-end) (if block-cursor? 1 0))))
-      (when (>= (abs (- end beg)) selection-highlight-mode-min-length)
+      (when (and (>= (abs (- end beg)) selection-highlight-mode-min-length)
+                 (not (cl-some (lambda (regexp) (string-match-p regexp (buffer-substring beg end)))
+                               selection-highlight-ignored-matches)))
         (buffer-substring beg end)))))
 
 ;;; Hooks


### PR DESCRIPTION
This adds a way to exclude any arbitrary text from the highlighted selections (configured as a list of regular expressions to ignore).

The default value is set to ignore space-only selections. We can set it to `nil` by default so we keep the current behavior, with the user being able to customize it easily.

This PR will fixes the issue addressed by #2 when the value is set to ignore space-only regions. So, it is a more generic approach to fix this issue.